### PR TITLE
fix: harden bot against data loss, perm gaps, races, and prod hazards

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,6 +27,7 @@ jobs:
       attestations: write
       id-token: write
       security-events: write
+      pull-requests: write  # for the "Comment PR" step
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
       attestations: write
       id-token: write
       security-events: write
-      pull-requests: write  # for the "Comment PR" step
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -87,15 +87,13 @@ jobs:
           subject-digest: ${{ steps.build-push.outputs.digest }}
           push-to-registry: true
 
-      # Test the built image
       - name: Test Docker image
         if: github.event_name != 'pull_request'
         run: |
-          # Test that the image can be run (will fail without Discord token, but should start)
+          # Image will exit without DISCORD_TOKEN; we just check it starts.
           timeout 10s docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} || true
           echo "Docker image test completed"
 
-      # Comment on PR with image details
       - name: Comment PR
         uses: actions/github-script@v9
         if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Git worktrees
+.worktrees/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# Pin to a specific patch version. Bump deliberately via PR.
-FROM python:3.13.13-alpine3.23 AS deps
+FROM python:3.13-alpine AS deps
 
 WORKDIR /app
 
@@ -11,7 +10,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Build final image
-FROM python:3.13.13-alpine3.23
+FROM python:3.13-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV PATH="/opt/venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-COPY *.py ./
+COPY *.py .
 
 # Drop root: create an unprivileged user and own /app.
 RUN addgroup -S threadit && adduser -S -G threadit threadit \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Stage 1: Install dependencies
-FROM python:3.13-alpine AS deps
+# Pinned to a specific digest so rebuilds are reproducible and cannot be
+# silently shifted by an upstream tag move. Bump deliberately via PR.
+# python:3.13.13-alpine3.23
+FROM python:3.13.13-alpine3.23@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc AS deps
 
 WORKDIR /app
 
@@ -11,7 +13,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Build final image
-FROM python:3.13-alpine
+FROM python:3.13.13-alpine3.23@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc
 
 WORKDIR /app
 
@@ -19,8 +21,16 @@ WORKDIR /app
 # ENV LOG_LEVEL=INFO
 
 COPY --from=deps /opt/venv /opt/venv
-ENV PATH="/opt/venv/bin:$PATH"
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
-COPY *.py .
+COPY *.py ./
+
+# Drop root: create an unprivileged user and own /app.
+RUN addgroup -S threadit && adduser -S -G threadit threadit \
+    && chown -R threadit:threadit /app
+
+USER threadit
 
 CMD ["python", "bot.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-# Pinned to a specific digest so rebuilds are reproducible and cannot be
-# silently shifted by an upstream tag move. Bump deliberately via PR.
-FROM python:3.13.13-alpine3.23@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc AS deps
+# Pin to a specific patch version. Bump deliberately via PR.
+FROM python:3.13.13-alpine3.23 AS deps
 
 WORKDIR /app
 
@@ -12,7 +11,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Stage 2: Build final image
-FROM python:3.13.13-alpine3.23@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc
+FROM python:3.13.13-alpine3.23
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Pinned to a specific digest so rebuilds are reproducible and cannot be
 # silently shifted by an upstream tag move. Bump deliberately via PR.
-# python:3.13.13-alpine3.23
 FROM python:3.13.13-alpine3.23@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc AS deps
 
 WORKDIR /app

--- a/bot.py
+++ b/bot.py
@@ -45,11 +45,18 @@ class ThreadItBot(discord.Client):
 
         # Per-parent-message locks serialize thread creation when multiple
         # replies arrive for the same parent in quick succession.
+        # Value is [lock, waiter_count]; popped when waiter_count drops to 0
+        # to avoid an unbounded dict over the bot's lifetime.
         self._parent_locks = {}
 
         # Per-channel cooldown for in-channel permission warnings, to avoid
         # spamming a misconfigured server on every reply.
         self._permission_warning_sent_at = {}
+
+        # Strong references to fire-and-forget background tasks so the
+        # event loop doesn't GC them mid-await ("Task was destroyed but
+        # it is pending"). Tasks remove themselves on completion.
+        self._background_tasks = set()
 
         # Configure logging
         self.setup_logging()
@@ -244,20 +251,40 @@ class ThreadItBot(discord.Client):
             # Serialize per-parent-message so concurrent replies don't race
             # the "thread exists?" check and end up creating duplicates / dropping replies.
             parent_id = reply_info['parent_message'].id
-            lock = self._parent_locks.setdefault(parent_id, asyncio.Lock())
-            async with lock:
-                # Re-fetch the parent inside the lock so we pick up a thread
-                # that another coroutine just created.
-                try:
-                    parent = await reply_info['channel'].fetch_message(parent_id)
-                    reply_info['parent_message'] = parent
-                except (discord.NotFound, discord.Forbidden):
-                    pass
+            entry = self._parent_locks.setdefault(parent_id, [asyncio.Lock(), 0])
+            entry[1] += 1
+            thread = None
+            try:
+                async with entry[0]:
+                    # Re-fetch the parent inside the lock so we pick up a thread
+                    # that another coroutine just created.
+                    try:
+                        parent = await reply_info['channel'].fetch_message(parent_id)
+                        reply_info['parent_message'] = parent
+                    except discord.NotFound:
+                        self.logger.info(
+                            f"Parent message {parent_id} deleted before thread creation; skipping"
+                        )
+                        return
+                    except (discord.Forbidden, discord.HTTPException) as e:
+                        # Transient or permission issue on re-fetch — proceed with
+                        # the parent we already loaded in gather_reply_information.
+                        self.logger.warning(
+                            f"Re-fetch of parent {parent_id} failed ({e}); using cached copy"
+                        )
 
-                if reply_info['parent_message'].thread is not None:
-                    thread = reply_info['parent_message'].thread
-                else:
-                    thread = await self.create_thread_from_reply(reply_info)
+                    if reply_info['parent_message'].thread is not None:
+                        thread = reply_info['parent_message'].thread
+                    else:
+                        thread = await self.create_thread_from_reply(reply_info)
+            finally:
+                entry[1] -= 1
+                if entry[1] == 0:
+                    # Safe pop: under asyncio's single-threaded loop, a zero
+                    # waiter count means no other coroutine currently holds a
+                    # reference via setdefault, so dropping the entry cannot
+                    # race a peer's lock acquisition.
+                    self._parent_locks.pop(parent_id, None)
 
             if thread is None:
                 self.logger.warning(f"Failed to create thread for reply {reply_info['message_id']}")
@@ -628,7 +655,11 @@ class ThreadItBot(discord.Client):
                 )
                 # Defer the auto-delete so the main flow returns promptly and
                 # we don't hold the process_reply task open for 8 seconds.
-                asyncio.create_task(self._delete_after(notification_message, 8))
+                # Keep a strong reference so the event loop doesn't GC the
+                # task mid-await; remove it when done.
+                task = asyncio.create_task(self._delete_after(notification_message, 8))
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
             else:
                 self.logger.debug(
                     f"Sent notification message {notification_message.id} in #{channel.name} - "
@@ -650,7 +681,7 @@ class ThreadItBot(discord.Client):
             await asyncio.sleep(delay_seconds)
             await message.delete()
             self.logger.debug(
-                f"Auto-deleted notification message {message.id} in #{message.channel.name}"
+                f"Auto-deleted notification message {message.id} in #{getattr(message.channel, 'name', '?')}"
             )
         except discord.NotFound:
             pass

--- a/bot.py
+++ b/bot.py
@@ -6,18 +6,23 @@ A Discord bot that automatically converts message replies into organized public 
 This keeps main channel feeds clean and ensures follow-up discussions are neatly contained.
 """
 
-import os
 import io
 import logging
 import asyncio
+import time
 from typing import Optional
 import discord
-from discord.ext import commands
-from dotenv import load_dotenv
 from config import Config
 
-# Load environment variables
-load_dotenv()
+# Default invite URL client_id used in static error text before login.
+# At runtime we prefer self.user.id so self-hosters get a link pointing at
+# their own bot, not the upstream deployment.
+DEFAULT_CLIENT_ID = "1386888801229734018"
+
+
+def invite_url(client_id) -> str:
+    return f"https://discord.com/oauth2/authorize?client_id={client_id}"
+
 
 class ThreadItBot(discord.Client):
     """
@@ -31,10 +36,27 @@ class ThreadItBot(discord.Client):
         intents.guilds = True          # Required for guild events
         intents.guild_messages = True  # Required for message events
 
-        super().__init__(intents=intents)
+        # Default to no mentions on any bot-authored send. Specific
+        # notifications opt back in to a narrow allow-list.
+        super().__init__(
+            intents=intents,
+            allowed_mentions=discord.AllowedMentions.none(),
+        )
+
+        # Per-parent-message locks serialize thread creation when multiple
+        # replies arrive for the same parent in quick succession.
+        self._parent_locks = {}
+
+        # Per-channel cooldown for in-channel permission warnings, to avoid
+        # spamming a misconfigured server on every reply.
+        self._permission_warning_sent_at = {}
 
         # Configure logging
         self.setup_logging()
+
+    def _client_id(self):
+        """Return our bot's client_id once logged in, falling back to default."""
+        return str(self.user.id) if self.user else DEFAULT_CLIENT_ID
 
     def setup_logging(self):
         """Configure logging based on environment variables."""
@@ -111,9 +133,6 @@ class ThreadItBot(discord.Client):
 
         # Handle help command
         if message.content.lower().startswith("!thread-it"):
-            # Check permissions and include setup guidance if needed
-            has_required_perms, missing_required, missing_optional = self.validate_permissions(message.channel)
-
             help_message = (
                 "Hi there! I'm Thread It. My purpose is to keep your Discord channels clean "
                 "by automatically converting message replies into organized public threads.\n\n"
@@ -126,30 +145,35 @@ class ThreadItBot(discord.Client):
                 "**No commands are needed for my core function!** Just reply to a message, and I'll do the rest."
             )
 
-            # Add permission status information
-            if not has_required_perms:
-                permission_list = "\n".join(f"• {perm}" for perm in missing_required)
-                help_message += (
-                    f"\n\n⚠️ **Permission Setup Required**\n"
-                    f"I'm currently missing some required permissions in this channel:\n\n"
-                    f"{permission_list}\n\n"
-                    "**To fix this:**\n"
-                    "1. Go to Server Settings → Roles\n"
-                    "2. Find the 'Thread It' role (or @Thread It)\n"
-                    "3. Enable the missing permissions listed above\n"
-                    "4. Or re-invite me with the correct permissions: https://discord.com/oauth2/authorize?client_id=1386888801229734018"
-                )
-            elif missing_optional:
-                help_message += (
-                    f"\n\n📝 **Optional Enhancement**\n"
-                    f"For the best experience, consider granting the 'Manage Messages' permission. "
-                    f"This allows me to clean up the original reply messages after moving them to threads. "
-                    f"Without this permission, I'll still create threads but won't delete the original replies."
-                )
-            else:
-                help_message += (
-                    f"\n\n✅ **All permissions are correctly set up!** I'm ready to organize your conversations."
-                )
+            # In a DM the bot has no per-channel permission state to surface,
+            # so skip the permission block entirely.
+            if message.guild is not None:
+                has_required_perms, missing_required, missing_optional = self.validate_permissions(message.channel)
+
+                # Add permission status information
+                if not has_required_perms:
+                    permission_list = "\n".join(f"• {perm}" for perm in missing_required)
+                    help_message += (
+                        f"\n\n⚠️ **Permission Setup Required**\n"
+                        f"I'm currently missing some required permissions in this channel:\n\n"
+                        f"{permission_list}\n\n"
+                        "**To fix this:**\n"
+                        "1. Go to Server Settings → Roles\n"
+                        "2. Find the 'Thread It' role (or @Thread It)\n"
+                        "3. Enable the missing permissions listed above\n"
+                        f"4. Or re-invite me with the correct permissions: {invite_url(self._client_id())}"
+                    )
+                elif missing_optional:
+                    help_message += (
+                        f"\n\n📝 **Optional Enhancement**\n"
+                        f"For the best experience, consider granting the 'Manage Messages' permission. "
+                        f"This allows me to clean up the original reply messages after moving them to threads. "
+                        f"Without this permission, I'll still create threads but won't delete the original replies."
+                    )
+                else:
+                    help_message += (
+                        f"\n\n✅ **All permissions are correctly set up!** I'm ready to organize your conversations."
+                    )
 
             await message.reply(help_message)
             return
@@ -191,7 +215,10 @@ class ThreadItBot(discord.Client):
                 return
 
             # Check permissions before proceeding
-            has_required_perms, missing_required, missing_optional = self.validate_permissions(message.channel)
+            has_attachments = bool(message.attachments)
+            has_required_perms, missing_required, missing_optional = self.validate_permissions(
+                message.channel, has_attachments=has_attachments
+            )
             if not has_required_perms:
                 self.logger.error(
                     f"Missing required permissions in #{message.channel.name}: {', '.join(missing_required)}"
@@ -214,11 +241,23 @@ class ThreadItBot(discord.Client):
                 await self.log_operation_metrics("gather_reply_info", False, error="Failed to gather info")
                 return
 
-            # Create or retrieve thread and repost content
-            if reply_info['parent_message'].thread is not None:
-                thread = reply_info['parent_message'].thread
-            else:
-                thread = await self.create_thread_from_reply(reply_info)
+            # Serialize per-parent-message so concurrent replies don't race
+            # the "thread exists?" check and end up creating duplicates / dropping replies.
+            parent_id = reply_info['parent_message'].id
+            lock = self._parent_locks.setdefault(parent_id, asyncio.Lock())
+            async with lock:
+                # Re-fetch the parent inside the lock so we pick up a thread
+                # that another coroutine just created.
+                try:
+                    parent = await reply_info['channel'].fetch_message(parent_id)
+                    reply_info['parent_message'] = parent
+                except (discord.NotFound, discord.Forbidden):
+                    pass
+
+                if reply_info['parent_message'].thread is not None:
+                    thread = reply_info['parent_message'].thread
+                else:
+                    thread = await self.create_thread_from_reply(reply_info)
 
             if thread is None:
                 self.logger.warning(f"Failed to create thread for reply {reply_info['message_id']}")
@@ -228,7 +267,13 @@ class ThreadItBot(discord.Client):
             repost_success = await self.repost_reply_in_thread(thread, reply_info)
 
             if not repost_success:
-                self.logger.warning(f"Failed to repost content in thread {thread.id}")
+                # Repost failed (including partial attachment loss). Do NOT
+                # delete the original message; the user's content is still
+                # only safely available in the source channel.
+                self.logger.warning(
+                    f"Repost incomplete for reply {reply_info['message_id']}; "
+                    f"leaving original message intact to avoid data loss"
+                )
                 return
 
             # Clean up messages as specified in design document
@@ -357,6 +402,42 @@ class ThreadItBot(discord.Client):
             )
             return None
 
+    async def _build_attachment_files(self, attachments):
+        """
+        Download attachments and convert them into discord.File objects,
+        enforcing the per-attachment size cap so a malicious or unlucky
+        upload can't OOM a small host.
+
+        Returns:
+            (files, all_succeeded) - all_succeeded is False if any attachment
+            was skipped (oversize) or failed to download.
+        """
+        files = []
+        all_succeeded = True
+        max_bytes = Config.MAX_ATTACHMENT_BYTES
+
+        for attachment in attachments:
+            if attachment.size and attachment.size > max_bytes:
+                self.logger.warning(
+                    f"Skipping oversize attachment {attachment.filename} "
+                    f"({attachment.size} bytes > {max_bytes} byte limit)"
+                )
+                all_succeeded = False
+                continue
+
+            try:
+                file_data = await attachment.read()
+                files.append(discord.File(
+                    fp=io.BytesIO(file_data),
+                    filename=attachment.filename,
+                    description=attachment.description,
+                ))
+            except Exception as e:
+                self.logger.warning(f"Failed to process attachment {attachment.filename}: {e}")
+                all_succeeded = False
+
+        return files, all_succeeded
+
     async def repost_reply_in_thread(self, thread, reply_info):
         """
         Repost the original reply content in the newly created thread.
@@ -388,21 +469,10 @@ class ThreadItBot(discord.Client):
             # Add timestamp
             embed.timestamp = reply_info['created_at']
 
-            # Prepare files for attachments
-            files = []
-            if reply_info['attachments']:
-                for attachment in reply_info['attachments']:
-                    try:
-                        # Download and re-upload the attachment
-                        file_data = await attachment.read()
-                        discord_file = discord.File(
-                            fp=io.BytesIO(file_data),
-                            filename=attachment.filename,
-                            description=attachment.description
-                        )
-                        files.append(discord_file)
-                    except Exception as e:
-                        self.logger.warning(f"Failed to process attachment {attachment.filename}: {e}")
+            # Prepare files for attachments. attachments_ok is False if any
+            # attachment was skipped (oversize) or failed to download; the
+            # caller uses this to avoid deleting the original message.
+            files, attachments_ok = await self._build_attachment_files(reply_info['attachments'])
 
             # Combine the new embed with any existing embeds from the original message
             all_embeds = [embed] + reply_info['embeds']
@@ -428,11 +498,12 @@ class ThreadItBot(discord.Client):
                 f"Reposted reply content in thread {thread.id} with embed attribution: "
                 f"content_length={len(content)}, "
                 f"attachments={len(reply_info['attachments'])}, "
+                f"attachments_reposted={len(files)}, "
                 f"original_embeds={len(reply_info['embeds'])}, "
                 f"total_embeds={len(all_embeds)}"
             )
 
-            return True
+            return attachments_ok
 
         except discord.Forbidden:
             self.logger.error(f"Missing permissions to send message in thread {thread.id}")
@@ -538,8 +609,16 @@ class ThreadItBot(discord.Client):
                     f"Please continue your conversation there!"
                 )
 
+            # Allow mentioning only the addressed user; suppress @everyone /
+            # @here / role mentions in case any sneak through the embed.
+            allowed = discord.AllowedMentions(
+                users=[user], roles=False, everyone=False, replied_user=False
+            )
+
             # Send the notification message
-            notification_message = await channel.send(notification_content)
+            notification_message = await channel.send(
+                notification_content, allowed_mentions=allowed
+            )
 
             # Schedule automatic deletion after 8 seconds (if we have permission)
             if deletion_successful:
@@ -547,9 +626,9 @@ class ThreadItBot(discord.Client):
                     f"Sent temporary notification to {user} in #{channel.name}, "
                     f"message will auto-delete in 8 seconds"
                 )
-                await asyncio.sleep(8)
-                await notification_message.delete()
-                self.logger.debug(f"Auto-deleted notification message {notification_message.id} in #{channel.name}")
+                # Defer the auto-delete so the main flow returns promptly and
+                # we don't hold the process_reply task open for 8 seconds.
+                asyncio.create_task(self._delete_after(notification_message, 8))
             else:
                 self.logger.debug(
                     f"Sent notification message {notification_message.id} in #{channel.name} - "
@@ -564,6 +643,27 @@ class ThreadItBot(discord.Client):
             self.logger.error(f"HTTP error sending notification message: {e}")
         except Exception as e:
             self.logger.exception(f"Unexpected error sending temporary notification: {e}")
+
+    async def _delete_after(self, message, delay_seconds):
+        """Best-effort deletion of a temporary message after a delay."""
+        try:
+            await asyncio.sleep(delay_seconds)
+            await message.delete()
+            self.logger.debug(
+                f"Auto-deleted notification message {message.id} in #{message.channel.name}"
+            )
+        except discord.NotFound:
+            pass
+        except discord.Forbidden:
+            self.logger.warning(
+                f"Lost manage_messages permission before auto-deleting notification {message.id}"
+            )
+        except discord.HTTPException as e:
+            self.logger.warning(f"HTTP error auto-deleting notification {message.id}: {e}")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self.logger.warning(f"Unexpected error auto-deleting notification {message.id}: {e}")
 
     async def delete_system_thread_message(self, message):
         """
@@ -585,7 +685,7 @@ class ThreadItBot(discord.Client):
         except Exception as e:
             self.logger.exception(f"Unexpected error deleting system thread message {message.id}: {e}")
 
-    def validate_permissions(self, channel):
+    def validate_permissions(self, channel, has_attachments: bool = False):
         """
         Validate that the bot has necessary permissions in the channel.
         Separates required permissions (bot fails gracefully if missing) from
@@ -593,11 +693,12 @@ class ThreadItBot(discord.Client):
 
         Args:
             channel: The channel to check permissions for
+            has_attachments: When True, attach_files is also required.
 
         Returns:
             tuple: (has_required_permissions, missing_required_permissions, missing_optional_permissions)
         """
-        if not channel.guild:
+        if not getattr(channel, 'guild', None):
             return False, ["Not a guild channel"], []
 
         bot_member = channel.guild.get_member(self.user.id)
@@ -608,14 +709,20 @@ class ThreadItBot(discord.Client):
         missing_required = []
         missing_optional = []
 
-        # Required permissions - bot cannot function without these
+        # Required permissions - bot cannot function without these.
+        # embed_links is needed because we always post via discord.Embed;
+        # attach_files is added below only when the reply has attachments.
         required_permissions = [
             ('view_channel', 'View Channels'),
             ('send_messages', 'Send Messages'),
             ('send_messages_in_threads', 'Send Messages in Threads'),
             ('create_public_threads', 'Create Public Threads'),
-            ('read_message_history', 'Read Message History')
+            ('read_message_history', 'Read Message History'),
+            ('embed_links', 'Embed Links'),
         ]
+
+        if has_attachments:
+            required_permissions.append(('attach_files', 'Attach Files'))
 
         # Optional permissions - bot can work without these but with reduced functionality
         optional_permissions = [
@@ -643,7 +750,7 @@ class ThreadItBot(discord.Client):
         Returns:
             bool: True if the bot has the permission, False otherwise
         """
-        if not channel.guild:
+        if not getattr(channel, 'guild', None):
             return False
 
         bot_member = channel.guild.get_member(self.user.id)
@@ -668,6 +775,17 @@ class ThreadItBot(discord.Client):
             )
             return
 
+        # Rate-limit per channel so a misconfigured server doesn't get spammed
+        # with the same warning on every reply.
+        now = time.monotonic()
+        last_sent = self._permission_warning_sent_at.get(channel.id, 0.0)
+        if now - last_sent < Config.PERMISSION_WARNING_COOLDOWN_SECONDS:
+            self.logger.debug(
+                f"Suppressing duplicate permission warning in #{channel.name} "
+                f"(cooldown {Config.PERMISSION_WARNING_COOLDOWN_SECONDS}s)"
+            )
+            return
+
         try:
             permission_list = "\n".join(f"• {perm}" for perm in missing_required_permissions)
             error_message = (
@@ -678,10 +796,11 @@ class ThreadItBot(discord.Client):
                 "1. Go to Server Settings → Roles\n"
                 "2. Find the 'Thread It' role (or @Thread It)\n"
                 "3. Enable the missing permissions listed above\n"
-                "4. Or re-invite me with the correct permissions: https://discord.com/oauth2/authorize?client_id=1386888801229734018\n\n"
+                f"4. Or re-invite me with the correct permissions: {invite_url(self._client_id())}\n\n"
             )
 
             await channel.send(error_message)
+            self._permission_warning_sent_at[channel.id] = now
             self.logger.info(f"Sent permission error message to #{channel.name}")
 
         except discord.Forbidden:
@@ -713,6 +832,8 @@ class ThreadItBot(discord.Client):
                 ('view_channel', 'View Channels'),
                 ('send_messages', 'Send Messages'),
                 ('create_public_threads', 'Create Public Threads'),
+                ('embed_links', 'Embed Links'),
+                ('attach_files', 'Attach Files'),
                 ('manage_messages', 'Manage Messages'),
                 ('read_message_history', 'Read Message History')
             ]

--- a/config.py
+++ b/config.py
@@ -4,7 +4,27 @@ Handles all configuration settings and constants.
 """
 
 import os
+import re
+import unicodedata
 from typing import Optional
+
+from dotenv import load_dotenv
+
+# Load .env before any Config attributes are evaluated.
+load_dotenv()
+
+
+# Strip Unicode control (Cc) and format (Cf) characters except common
+# whitespace. This catches zero-width chars, bidi overrides, and other
+# invisible glyphs that would otherwise survive into thread names.
+_CONTROL_CHARS = ''.join(
+    chr(c) for c in range(0x110000)
+    if unicodedata.category(chr(c)) in ('Cc', 'Cf') and chr(c) not in '\t\n\r '
+)
+_CONTROL_CHARS_RE = re.compile(f'[{re.escape(_CONTROL_CHARS)}]')
+_EVERYONE_RE = re.compile(r'@(everyone|here)\b', re.IGNORECASE)
+_WHITESPACE_RE = re.compile(r'\s+')
+
 
 class Config:
     """Configuration class containing all bot settings."""
@@ -19,6 +39,17 @@ class Config:
     DEFAULT_AUTO_ARCHIVE_DURATION: int = 1440  # 24 hours in minutes
     MAX_THREAD_NAME_LENGTH: int = 100  # Discord's limit for thread names
 
+    # Attachment Configuration
+    # Per-attachment cap to avoid OOM on small hosts. Discord's per-file
+    # limit for non-boosted servers is 25 MiB; we mirror that as the default.
+    MAX_ATTACHMENT_BYTES: int = int(
+        os.getenv('MAX_ATTACHMENT_BYTES', str(25 * 1024 * 1024))
+    )
+
+    # Rate-limit for in-channel "missing permission" warnings, per channel.
+    PERMISSION_WARNING_COOLDOWN_SECONDS: int = int(
+        os.getenv('PERMISSION_WARNING_COOLDOWN_SECONDS', '3600')
+    )
 
     @classmethod
     def validate(cls) -> None:
@@ -44,15 +75,23 @@ class Config:
         if not original_message_content or original_message_content.isspace():
             return "Discussion Thread"
 
-        # Remove mentions, links, and other Discord formatting
+        # Normalize and strip invisible control/format characters first so
+        # tokenization below cannot be fooled by zero-width joins.
+        normalized = unicodedata.normalize('NFKC', original_message_content)
+        normalized = _CONTROL_CHARS_RE.sub('', normalized)
+        normalized = _EVERYONE_RE.sub('', normalized)
+
+        # Remove mentions, links, and other Discord formatting tokens.
         cleaned = ' '.join(
-            word for word in original_message_content.split()
+            word for word in normalized.split()
             if not (
                 word.startswith(('<@', '<#', 'http://', 'https://')) or
                 (word.startswith('||') and word.endswith('||')) or
                 (word.startswith('`') and word.endswith('`'))
             )
         )
+
+        cleaned = _WHITESPACE_RE.sub(' ', cleaned).strip()
 
         # Truncate to Discord's limit
         if len(cleaned) > cls.MAX_THREAD_NAME_LENGTH:

--- a/config.py
+++ b/config.py
@@ -26,6 +26,19 @@ _EVERYONE_RE = re.compile(r'@(everyone|here)\b', re.IGNORECASE)
 _WHITESPACE_RE = re.compile(r'\s+')
 
 
+def _int_env(name: str, default: int) -> int:
+    """Read an integer env var; raise a clear error instead of Python's default."""
+    raw = os.getenv(name)
+    if raw is None or raw == '':
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"Environment variable {name} must be an integer, got {raw!r}"
+        ) from exc
+
+
 class Config:
     """Configuration class containing all bot settings."""
 
@@ -42,13 +55,11 @@ class Config:
     # Attachment Configuration
     # Per-attachment cap to avoid OOM on small hosts. Discord's per-file
     # limit for non-boosted servers is 25 MiB; we mirror that as the default.
-    MAX_ATTACHMENT_BYTES: int = int(
-        os.getenv('MAX_ATTACHMENT_BYTES', str(25 * 1024 * 1024))
-    )
+    MAX_ATTACHMENT_BYTES: int = _int_env('MAX_ATTACHMENT_BYTES', 25 * 1024 * 1024)
 
     # Rate-limit for in-channel "missing permission" warnings, per channel.
-    PERMISSION_WARNING_COOLDOWN_SECONDS: int = int(
-        os.getenv('PERMISSION_WARNING_COOLDOWN_SECONDS', '3600')
+    PERMISSION_WARNING_COOLDOWN_SECONDS: int = _int_env(
+        'PERMISSION_WARNING_COOLDOWN_SECONDS', 3600
     )
 
     @classmethod


### PR DESCRIPTION
## Summary

Addresses the critical and high-priority findings from a multi-reviewer audit (Codex security, Codex quality, Gemini independent). Split into one PR so the fixes ship together; tooling/test scaffolding will follow.

## Data loss / correctness

- **`.env` not loaded in time** — `config.py` now calls `load_dotenv()` before `Config` attributes are evaluated. Previously `bot.py:17 from config import Config` ran before `bot.py:20 load_dotenv()`, so `DISCORD_TOKEN = os.getenv(...)` always saw `None` and the README setup flow silently failed unless the shell had already exported the token.
- **Attachment failures dropped user content** — `_build_attachment_files()` propagates failure (download error or oversize); `process_reply_to_thread` skips `cleanup_messages` when repost is incomplete, so the original message survives.
- **Concurrent-reply race** — `process_reply_to_thread` now holds a per-parent `asyncio.Lock` around the check-then-create sequence and re-fetches the parent inside the lock to pick up a thread another coroutine just created.

## Permissions

- Added `embed_links` (always required — every repost uses `discord.Embed`) and conditionally `attach_files` (only when the reply carries attachments) to `validate_permissions`. Without these the bot would create an empty thread and silently fail the `thread.send(embeds=..., files=...)`.
- `validate_permissions` and `check_specific_permission` use `getattr(channel, 'guild', None)` to handle DM channels without surprises.
- `send_permission_error_message` now rate-limits per-channel via `Config.PERMISSION_WARNING_COOLDOWN_SECONDS` (default 1h, env-overridable). Misconfigured servers no longer get spammed once per reply.

## Resource bounds

- `_build_attachment_files` enforces `Config.MAX_ATTACHMENT_BYTES` (default 25 MiB, env-overridable). Previously every attachment was fully buffered in RAM, which could OOM small Docker hosts.

## Notification handling

- Notification sends now pass `AllowedMentions(users=[user], everyone=False, roles=False, replied_user=False)`. Suppresses `@everyone`/`@here`/role pings even if a future content change ever lets one through.
- Auto-delete deferred via `asyncio.create_task(self._delete_after(notification_message, 8))` instead of `await asyncio.sleep(8); await delete()` inline. The main flow now returns promptly, and `_delete_after` has its own try/except so a delete failure is reported instead of being swallowed by the outer handler.

## Self-host friendliness

- Help and error messages now build their invite URL from `self.user.id` (with the upstream id as a fallback for pre-login static text). Forks no longer point users at the upstream bot.
- `discord.Client` initialized with `allowed_mentions=AllowedMentions.none()` as a safe default for any bot-authored send.

## Thread name sanitization

- `Config.get_thread_name` NFKC-normalizes input, strips Unicode `Cc`/`Cf` (zero-width chars, bidi overrides), and removes `@everyone`/`@here` tokens before existing mention/link filtering. Prevents visually-misleading thread names.

## Docker

- (reverted) Base image left at python:3.13-alpine per maintainer preference; digest pinning was overkill for this project.
- Runs as an unprivileged `threadit` user instead of root.
- Sets `PYTHONDONTWRITEBYTECODE=1` and `PYTHONUNBUFFERED=1`.

## Cleanup

- Removed unused `from discord.ext import commands` and `import os`.

## Test plan

- [x] `python -c "import ast; ast.parse(open('bot.py').read())"` — syntax check
- [x] `Config.get_thread_name` smoke tests for `@everyone`, `@here`, zero-width chars, bidi overrides, links, mentions, code/spoiler tokens, truncation
- [x] Dotenv ordering verified: importing `Config` in a fresh process with a `.env` file picks up `DISCORD_TOKEN` without any explicit `load_dotenv` call from the consumer
- [x] `ThreadItBot()` instantiates with `allowed_mentions=AllowedMentions(everyone=False, users=False, roles=False, replied_user=False)` and correct fallback `client_id`
- [ ] **Manual end-to-end** against a Discord test server (recommended before merge): happy-path reply, permissionless channel (no `embed_links`), oversize attachment, concurrent burst of replies to the same parent

## Findings not included in this PR

Deferred to follow-ups: pytest scaffolding, `pyproject.toml` + ruff/mypy + Python CI, modest module split (`cogs/threading.py` + `services/`), logging-privacy tightening, requirements lockfile.

Pushed back on (verified incorrect): "asyncio.sleep blocks event loop", "DM `!thread-it` crashes" (returns gracefully — but the DM UX nit is still addressed here), "replies to bot's own reposts loop" (already caught by `message.author.bot`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permission error messages now include bot re-invite URLs for easier access
  * Added per-attachment size limit enforcement (25 MB maximum)
  * Configuration now loads from `.env` file

* **Bug Fixes**
  * Prevented duplicate thread creation during concurrent operations
  * Improved permission validation for messages with attachments

* **Chores**
  * Enhanced Docker image security with pinned digest and non-root user
  * Updated thread name normalization for improved content handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wei/thread-it/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## ⚠️ Upgrade note for existing operators

After this change, the bot **requires `Embed Links`** in every channel it operates in. The bot has always posted via `discord.Embed`, but `channel.send` silently drops embeds when `embed_links` is missing — so previously the bot appeared to "work" while posting blank messages. After upgrading, it will instead refuse to process the reply and post a single (rate-limited) permission warning. If your bot role wasn't granted `Embed Links`, grant it before deploying.

## Follow-up review fixes (commit b32a319)

Code review (general-purpose subagent) caught three Important issues that have been addressed:

- **`_parent_locks` was unbounded.** Now uses `[lock, waiter_count]` entries with finally-pop when the count hits zero. Concurrency-verified: three overlapping coroutines on the same parent_id serialize strictly (A→B→C), and the dict empties after every burst including the single-coroutine case.
- **Re-fetch swallowed `NotFound`.** If the parent was deleted between `gather_reply_information` and lock acquisition, the code proceeded with a stale parent and would 404 on `create_thread`. Now bails on `NotFound` with an info log; `Forbidden`/`HTTPException` fall back to the cached parent.
- **`asyncio.create_task` without a reference.** The deferred auto-delete task was eligible for GC mid-await (the classic "Task was destroyed but it is pending!" bug). Now stored in `self._background_tasks` with `add_done_callback(self._background_tasks.discard)`.

