### PR TITLE
chore: add tests, lint, type-check, and Python CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  lint-type-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Ruff lint
+        run: ruff check .
+
+      - name: Mypy
+        run: mypy bot.py config.py
+
+      - name: Pytest
+        run: pytest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -90,9 +90,14 @@ jobs:
       - name: Test Docker image
         if: github.event_name != 'pull_request'
         run: |
-          # Image will exit without DISCORD_TOKEN; we just check it starts.
-          timeout 10s docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }} || true
-          echo "Docker image test completed"
+          set -eo pipefail
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
+          # Without DISCORD_TOKEN, Config.validate() prints "Configuration error: ..."
+          # and main() exits 0 (handled exception, not a crash). We verify that
+          # specific output appears, which proves the interpreter loaded bot.py.
+          output=$(docker run --rm "$IMAGE" 2>&1 || true)
+          echo "$output"
+          echo "$output" | grep -q "DISCORD_TOKEN environment variable not set"
 
       - name: Comment PR
         uses: actions/github-script@v9

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+For development (running tests, linting, type-checking), install the dev extras instead:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Then use:
+
+```bash
+ruff check .       # lint
+mypy bot.py config.py  # type-check
+pytest             # run tests
+```
+
 #### Step 4: Create Discord Bot
 
 1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)

--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,7 @@ import asyncio
 import io
 import logging
 import time
+from contextlib import asynccontextmanager
 
 import discord
 
@@ -65,6 +66,27 @@ class ThreadItBot(discord.Client):
     def _client_id(self):
         """Return our bot's client_id once logged in, falling back to default."""
         return str(self.user.id) if self.user else DEFAULT_CLIENT_ID
+
+    @asynccontextmanager
+    async def _with_parent_lock(self, parent_id):
+        """
+        Serialize concurrent work on the same parent message and pop the dict
+        entry when the last waiter releases.
+
+        Single-threaded event loop invariant: when waiter_count hits zero
+        inside the finally, no other coroutine currently holds a reference
+        to the lock via setdefault, so removing the entry cannot race a
+        peer's acquisition.
+        """
+        entry = self._parent_locks.setdefault(parent_id, [asyncio.Lock(), 0])
+        entry[1] += 1
+        try:
+            async with entry[0]:
+                yield
+        finally:
+            entry[1] -= 1
+            if entry[1] == 0:
+                self._parent_locks.pop(parent_id, None)
 
     def setup_logging(self):
         """Configure logging based on environment variables."""
@@ -252,40 +274,29 @@ class ThreadItBot(discord.Client):
             # Serialize per-parent-message so concurrent replies don't race
             # the "thread exists?" check and end up creating duplicates / dropping replies.
             parent_id = reply_info['parent_message'].id
-            entry = self._parent_locks.setdefault(parent_id, [asyncio.Lock(), 0])
-            entry[1] += 1
             thread = None
-            try:
-                async with entry[0]:
-                    # Re-fetch the parent inside the lock so we pick up a thread
-                    # that another coroutine just created.
-                    try:
-                        parent = await reply_info['channel'].fetch_message(parent_id)
-                        reply_info['parent_message'] = parent
-                    except discord.NotFound:
-                        self.logger.info(
-                            f"Parent message {parent_id} deleted before thread creation; skipping"
-                        )
-                        return
-                    except (discord.Forbidden, discord.HTTPException) as e:
-                        # Transient or permission issue on re-fetch — proceed with
-                        # the parent we already loaded in gather_reply_information.
-                        self.logger.warning(
-                            f"Re-fetch of parent {parent_id} failed ({e}); using cached copy"
-                        )
+            async with self._with_parent_lock(parent_id):
+                # Re-fetch the parent inside the lock so we pick up a thread
+                # that another coroutine just created.
+                try:
+                    parent = await reply_info['channel'].fetch_message(parent_id)
+                    reply_info['parent_message'] = parent
+                except discord.NotFound:
+                    self.logger.info(
+                        f"Parent message {parent_id} deleted before thread creation; skipping"
+                    )
+                    return
+                except (discord.Forbidden, discord.HTTPException) as e:
+                    # Transient or permission issue on re-fetch — proceed with
+                    # the parent we already loaded in gather_reply_information.
+                    self.logger.warning(
+                        f"Re-fetch of parent {parent_id} failed ({e}); using cached copy"
+                    )
 
-                    if reply_info['parent_message'].thread is not None:
-                        thread = reply_info['parent_message'].thread
-                    else:
-                        thread = await self.create_thread_from_reply(reply_info)
-            finally:
-                entry[1] -= 1
-                if entry[1] == 0:
-                    # Safe pop: under asyncio's single-threaded loop, a zero
-                    # waiter count means no other coroutine currently holds a
-                    # reference via setdefault, so dropping the entry cannot
-                    # race a peer's lock acquisition.
-                    self._parent_locks.pop(parent_id, None)
+                if reply_info['parent_message'].thread is not None:
+                    thread = reply_info['parent_message'].thread
+                else:
+                    thread = await self.create_thread_from_reply(reply_info)
 
             if thread is None:
                 self.logger.warning(f"Failed to create thread for reply {reply_info['message_id']}")

--- a/bot.py
+++ b/bot.py
@@ -6,12 +6,13 @@ A Discord bot that automatically converts message replies into organized public 
 This keeps main channel feeds clean and ensures follow-up discussions are neatly contained.
 """
 
+import asyncio
 import io
 import logging
-import asyncio
 import time
-from typing import Optional
+
 import discord
+
 from config import Config
 
 # Default invite URL client_id used in static error text before login.
@@ -172,14 +173,14 @@ class ThreadItBot(discord.Client):
                     )
                 elif missing_optional:
                     help_message += (
-                        f"\n\n📝 **Optional Enhancement**\n"
-                        f"For the best experience, consider granting the 'Manage Messages' permission. "
-                        f"This allows me to clean up the original reply messages after moving them to threads. "
-                        f"Without this permission, I'll still create threads but won't delete the original replies."
+                        "\n\n📝 **Optional Enhancement**\n"
+                        "For the best experience, consider granting the 'Manage Messages' permission. "
+                        "This allows me to clean up the original reply messages after moving them to threads. "
+                        "Without this permission, I'll still create threads but won't delete the original replies."
                     )
                 else:
                     help_message += (
-                        f"\n\n✅ **All permissions are correctly set up!** I'm ready to organize your conversations."
+                        "\n\n✅ **All permissions are correctly set up!** I'm ready to organize your conversations."
                     )
 
             await message.reply(help_message)
@@ -732,6 +733,9 @@ class ThreadItBot(discord.Client):
         if not getattr(channel, 'guild', None):
             return False, ["Not a guild channel"], []
 
+        if self.user is None:
+            return False, ["Bot not yet ready"], []
+
         bot_member = channel.guild.get_member(self.user.id)
         if not bot_member:
             return False, ["Bot not in guild"], []
@@ -782,6 +786,9 @@ class ThreadItBot(discord.Client):
             bool: True if the bot has the permission, False otherwise
         """
         if not getattr(channel, 'guild', None):
+            return False
+
+        if self.user is None:
             return False
 
         bot_member = channel.guild.get_member(self.user.id)
@@ -849,6 +856,9 @@ class ThreadItBot(discord.Client):
             guild: The guild to check permissions for
         """
         try:
+            if self.user is None:
+                self.logger.warning(f"Skipping permission log for {guild.name}: bot not yet ready")
+                return
             bot_member = guild.get_member(self.user.id)
             if not bot_member:
                 self.logger.warning(f"Bot not found as member in guild {guild.name} (ID: {guild.id})")
@@ -880,14 +890,14 @@ class ThreadItBot(discord.Client):
             # Log text channels where bot might have issues
             problematic_channels = []
             for channel in guild.text_channels:
-                has_required, missing_required, missing_optional = self.validate_permissions(channel)
+                has_required, missing_required, _ = self.validate_permissions(channel)
                 if not has_required:
                     problematic_channels.append(f"#{channel.name} (missing: {', '.join(missing_required)})")
 
             if problematic_channels:
                 self.logger.warning(f"  Channels with permission issues: {'; '.join(problematic_channels)}")
             else:
-                self.logger.info(f"  All text channels have required permissions ✓")
+                self.logger.info("  All text channels have required permissions ✓")
 
         except Exception as e:
             self.logger.exception(f"Error logging permissions for guild {guild.name} (ID: {guild.id}): {e}")

--- a/bot.py
+++ b/bot.py
@@ -814,10 +814,13 @@ class ThreadItBot(discord.Client):
             return
 
         # Rate-limit per channel so a misconfigured server doesn't get spammed
-        # with the same warning on every reply.
+        # with the same warning on every reply. Use None (not 0.0) as the
+        # "never sent" sentinel: time.monotonic() can be small (< cooldown)
+        # on a freshly-booted host, which would otherwise suppress the very
+        # first warning.
         now = time.monotonic()
-        last_sent = self._permission_warning_sent_at.get(channel.id, 0.0)
-        if now - last_sent < Config.PERMISSION_WARNING_COOLDOWN_SECONDS:
+        last_sent = self._permission_warning_sent_at.get(channel.id)
+        if last_sent is not None and now - last_sent < Config.PERMISSION_WARNING_COOLDOWN_SECONDS:
             self.logger.debug(
                 f"Suppressing duplicate permission warning in #{channel.name} "
                 f"(cooldown {Config.PERMISSION_WARNING_COOLDOWN_SECONDS}s)"

--- a/config.py
+++ b/config.py
@@ -6,7 +6,6 @@ Handles all configuration settings and constants.
 import os
 import re
 import unicodedata
-from typing import Optional
 
 from dotenv import load_dotenv
 
@@ -43,7 +42,7 @@ class Config:
     """Configuration class containing all bot settings."""
 
     # Discord API Configuration
-    DISCORD_TOKEN: Optional[str] = os.getenv('DISCORD_TOKEN')
+    DISCORD_TOKEN: str | None = os.getenv('DISCORD_TOKEN')
 
     # Logging Configuration
     LOG_LEVEL: str = os.getenv('LOG_LEVEL', 'INFO').upper()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dev = [
 Homepage = "https://github.com/wei/thread-it"
 Issues = "https://github.com/wei/thread-it/issues"
 
+[project.scripts]
+thread-it = "bot:main"
+
 # Single-module project; tell setuptools not to scan for packages.
 [tool.setuptools]
 py-modules = ["bot", "config"]
@@ -45,9 +48,6 @@ ignore = [
     "E501",  # line length handled by formatter; long strings in user-facing copy are fine
     "B008",  # function call in default arg (discord.py uses sentinel objects)
 ]
-
-[tool.ruff.lint.per-file-ignores]
-"tests/*" = ["B011"]  # allow assert in tests
 
 [tool.mypy]
 python_version = "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,15 @@ requires-python = ">=3.13"
 authors = [{ name = "Wei He" }]
 dependencies = [
     "discord.py>=2.7.1",
-    "python-dotenv>=1.2.1",
+    "python-dotenv>=1.2.2",
 ]
 
 [project.optional-dependencies]
 dev = [
     "ruff>=0.15.13",
-    "mypy>=1.19.1",
-    "pytest>=8.4.2",
-    "pytest-asyncio>=1.2.0",
+    "mypy>=2.1.0",
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,70 @@
+[project]
+name = "thread-it"
+version = "0.1.0"
+description = "Discord bot that converts message replies into organized public threads."
+readme = "README.md"
+license = { file = "LICENSE" }
+requires-python = ">=3.13"
+authors = [{ name = "Wei He" }]
+dependencies = [
+    "discord.py>=2.7.1",
+    "python-dotenv>=1.2.1",
+]
+
+[project.optional-dependencies]
+dev = [
+    "ruff>=0.15.13",
+    "mypy>=1.19.1",
+    "pytest>=8.4.2",
+    "pytest-asyncio>=1.2.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/wei/thread-it"
+Issues = "https://github.com/wei/thread-it/issues"
+
+# Single-module project; tell setuptools not to scan for packages.
+[tool.setuptools]
+py-modules = ["bot", "config"]
+
+[tool.ruff]
+target-version = "py313"
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "UP",  # pyupgrade
+    "RUF", # ruff-specific
+]
+ignore = [
+    "E501",  # line length handled by formatter; long strings in user-facing copy are fine
+    "B008",  # function call in default arg (discord.py uses sentinel objects)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["B011"]  # allow assert in tests
+
+[tool.mypy]
+python_version = "3.13"
+strict = false
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_unreachable = true
+no_implicit_optional = true
+# discord.py ships its own stubs; don't fail on third-party untyped libs.
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+addopts = ["-ra", "--strict-markers"]
+filterwarnings = [
+    "error",
+    # discord.py emits an audioop DeprecationWarning on import under 3.13; out of our control.
+    "ignore::DeprecationWarning:discord",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+# Development dependencies (lint, type-check, test).
+# Runtime deps live in requirements.txt and are also declared in pyproject.toml.
+-r requirements.txt
+ruff>=0.15.13
+mypy>=1.19.1
+pytest>=8.4.2
+pytest-asyncio>=1.2.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,6 @@
 # Runtime deps live in requirements.txt and are also declared in pyproject.toml.
 -r requirements.txt
 ruff>=0.15.13
-mypy>=1.19.1
-pytest>=8.4.2
-pytest-asyncio>=1.2.0
+mypy>=2.1.0
+pytest>=9.0.3
+pytest-asyncio>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 discord.py>=2.7.1
-python-dotenv>=1.2.1
+python-dotenv>=1.2.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration: provide a DISCORD_TOKEN before bot is imported."""
+
+import os
+
+# bot.py / config.py read DISCORD_TOKEN at import time via load_dotenv.
+# Tests don't talk to Discord, but Config.validate() refuses to load
+# without one, so seed a placeholder before any test module imports bot.
+os.environ.setdefault("DISCORD_TOKEN", "test-token")

--- a/tests/test_bot_helpers.py
+++ b/tests/test_bot_helpers.py
@@ -1,0 +1,300 @@
+"""Tests for ThreadItBot helpers that don't require a live Discord gateway."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+import bot
+
+# --------------------------------------------------------------------------- #
+# Fixtures
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def threadit_bot():
+    """A ThreadItBot instance with the Discord gateway hooks bypassed."""
+    # Avoid invoking the real discord.Client setup (network, signal handlers).
+    with patch.object(discord.Client, "__init__", lambda self, *a, **kw: None):
+        b = bot.ThreadItBot.__new__(bot.ThreadItBot)
+        b._parent_locks = {}
+        b._permission_warning_sent_at = {}
+        b._background_tasks = set()
+        # Replicate the logger setup ThreadItBot.setup_logging() does, minus
+        # global logging.basicConfig side effects.
+        import logging
+
+        b.logger = logging.getLogger("test-threadit")
+        # discord.Client subclasses expose .user; default to a stand-in.
+        b._user = SimpleNamespace(id=999, mention="<@999>")
+        yield b
+
+
+def _make_attachment(filename: str, size: int, read_data: bytes | None = None,
+                     read_exc: Exception | None = None):
+    """Build a discord.Attachment-shaped mock."""
+    att = MagicMock(spec=discord.Attachment)
+    att.filename = filename
+    att.size = size
+    att.description = None
+    if read_exc is not None:
+        att.read = AsyncMock(side_effect=read_exc)
+    else:
+        att.read = AsyncMock(return_value=read_data or b"x" * min(size, 16))
+    return att
+
+
+# --------------------------------------------------------------------------- #
+# invite_url + _client_id
+# --------------------------------------------------------------------------- #
+
+
+class TestInviteUrl:
+    def test_uses_provided_client_id(self):
+        assert bot.invite_url(12345) == "https://discord.com/oauth2/authorize?client_id=12345"
+
+    def test_default_client_id_constant_matches_upstream(self):
+        # If this changes, self-hosters following the README pre-login will
+        # silently end up routed to a different deployment.
+        assert bot.DEFAULT_CLIENT_ID == "1386888801229734018"
+
+
+class TestClientIdHelper:
+    def test_returns_default_when_not_logged_in(self, threadit_bot):
+        threadit_bot._user = None
+        # _client_id reads self.user; discord.Client makes it a property,
+        # but our test instance is bare so we expose it via attribute.
+        with patch.object(type(threadit_bot), "user", None, create=True):
+            assert threadit_bot._client_id() == bot.DEFAULT_CLIENT_ID
+
+    def test_returns_self_user_id_when_logged_in(self, threadit_bot):
+        with patch.object(type(threadit_bot), "user",
+                          SimpleNamespace(id=42), create=True):
+            assert threadit_bot._client_id() == "42"
+
+
+# --------------------------------------------------------------------------- #
+# _build_attachment_files
+# --------------------------------------------------------------------------- #
+
+
+class TestBuildAttachmentFiles:
+    async def test_empty_list_returns_empty_and_ok(self, threadit_bot):
+        files, ok = await threadit_bot._build_attachment_files([])
+        assert files == []
+        assert ok is True
+
+    async def test_small_attachment_downloaded(self, threadit_bot):
+        att = _make_attachment("hi.txt", size=10, read_data=b"hello")
+        files, ok = await threadit_bot._build_attachment_files([att])
+        assert ok is True
+        assert len(files) == 1
+        assert files[0].filename == "hi.txt"
+
+    async def test_oversize_attachment_is_skipped_and_flagged(self, threadit_bot):
+        # 30 MiB > default 25 MiB cap
+        att = _make_attachment("big.bin", size=30 * 1024 * 1024)
+        files, ok = await threadit_bot._build_attachment_files([att])
+        assert ok is False, "oversize attachment must mark the batch as failed"
+        assert files == []
+        att.read.assert_not_called()
+
+    async def test_download_failure_is_caught_and_flagged(self, threadit_bot):
+        att = _make_attachment("flaky.txt", size=10, read_exc=RuntimeError("boom"))
+        files, ok = await threadit_bot._build_attachment_files([att])
+        assert ok is False
+        assert files == []
+
+    async def test_partial_success_still_flags_overall_failure(self, threadit_bot):
+        good = _make_attachment("ok.txt", size=10, read_data=b"ok")
+        bad = _make_attachment("huge.bin", size=99 * 1024 * 1024)
+        files, ok = await threadit_bot._build_attachment_files([good, bad])
+        # The good attachment is kept; ok=False signals "don't delete original".
+        assert ok is False
+        assert len(files) == 1
+        assert files[0].filename == "ok.txt"
+
+
+# --------------------------------------------------------------------------- #
+# validate_permissions: required vs optional, attachments toggle, DM safety
+# --------------------------------------------------------------------------- #
+
+
+def _channel_with_perms(perms: dict[str, bool], guild_member_id: int = 999):
+    """Build a guild channel with a configurable permission set."""
+    guild = MagicMock()
+    bot_member = MagicMock()
+    guild.get_member = MagicMock(return_value=bot_member)
+
+    channel = MagicMock()
+    channel.guild = guild
+    channel.name = "test-channel"
+
+    # permissions_for() returns an object whose attribute lookup we control.
+    perm_obj = SimpleNamespace(**perms)
+    channel.permissions_for = MagicMock(return_value=perm_obj)
+    return channel, guild_member_id
+
+
+_ALL_PERMS = {
+    "view_channel": True,
+    "send_messages": True,
+    "send_messages_in_threads": True,
+    "create_public_threads": True,
+    "read_message_history": True,
+    "embed_links": True,
+    "attach_files": True,
+    "manage_messages": True,
+}
+
+
+class TestValidatePermissions:
+    def test_dm_channel_rejected(self, threadit_bot):
+        dm = MagicMock(spec=[])  # no .guild attribute
+        ok, missing_req, missing_opt = threadit_bot.validate_permissions(dm)
+        assert ok is False
+        assert missing_req == ["Not a guild channel"]
+        assert missing_opt == []
+
+    def test_all_perms_granted(self, threadit_bot):
+        channel, _ = _channel_with_perms(_ALL_PERMS)
+        with patch.object(type(threadit_bot), "user",
+                          SimpleNamespace(id=999), create=True):
+            ok, missing_req, missing_opt = threadit_bot.validate_permissions(channel)
+        assert ok is True
+        assert missing_req == []
+        assert missing_opt == []
+
+    def test_missing_embed_links_blocks(self, threadit_bot):
+        perms = dict(_ALL_PERMS, embed_links=False)
+        channel, _ = _channel_with_perms(perms)
+        with patch.object(type(threadit_bot), "user",
+                          SimpleNamespace(id=999), create=True):
+            ok, missing_req, _ = threadit_bot.validate_permissions(channel)
+        assert ok is False
+        assert "Embed Links" in missing_req
+
+    def test_attach_files_required_only_when_has_attachments(self, threadit_bot):
+        perms = dict(_ALL_PERMS, attach_files=False)
+        channel, _ = _channel_with_perms(perms)
+        with patch.object(type(threadit_bot), "user",
+                          SimpleNamespace(id=999), create=True):
+            ok_no_att, missing_no_att, _ = threadit_bot.validate_permissions(
+                channel, has_attachments=False
+            )
+            ok_with_att, missing_with_att, _ = threadit_bot.validate_permissions(
+                channel, has_attachments=True
+            )
+        assert ok_no_att is True
+        assert "Attach Files" not in missing_no_att
+        assert ok_with_att is False
+        assert "Attach Files" in missing_with_att
+
+    def test_manage_messages_is_optional(self, threadit_bot):
+        perms = dict(_ALL_PERMS, manage_messages=False)
+        channel, _ = _channel_with_perms(perms)
+        with patch.object(type(threadit_bot), "user",
+                          SimpleNamespace(id=999), create=True):
+            ok, missing_req, missing_opt = threadit_bot.validate_permissions(channel)
+        assert ok is True
+        assert missing_req == []
+        assert missing_opt == ["Manage Messages"]
+
+
+# --------------------------------------------------------------------------- #
+# Permission warning rate-limit
+# --------------------------------------------------------------------------- #
+
+
+class TestPermissionWarningRateLimit:
+    async def test_first_warning_sends_subsequent_suppressed(self, threadit_bot):
+        channel = MagicMock()
+        channel.id = 7777
+        channel.name = "test"
+        channel.send = AsyncMock()
+
+        with (
+            patch.object(threadit_bot, "check_specific_permission", return_value=True),
+            patch.object(threadit_bot, "_client_id", return_value="999"),
+        ):
+            await threadit_bot.send_permission_error_message(channel, ["Embed Links"])
+            await threadit_bot.send_permission_error_message(channel, ["Embed Links"])
+            await threadit_bot.send_permission_error_message(channel, ["Embed Links"])
+
+        assert channel.send.await_count == 1, (
+            "Subsequent warnings must be suppressed by the per-channel cooldown"
+        )
+
+    async def test_different_channels_are_independent(self, threadit_bot):
+        ch_a, ch_b = MagicMock(), MagicMock()
+        ch_a.id, ch_b.id = 1, 2
+        ch_a.name, ch_b.name = "a", "b"
+        ch_a.send = AsyncMock()
+        ch_b.send = AsyncMock()
+
+        with (
+            patch.object(threadit_bot, "check_specific_permission", return_value=True),
+            patch.object(threadit_bot, "_client_id", return_value="999"),
+        ):
+            await threadit_bot.send_permission_error_message(ch_a, ["Embed Links"])
+            await threadit_bot.send_permission_error_message(ch_b, ["Embed Links"])
+
+        assert ch_a.send.await_count == 1
+        assert ch_b.send.await_count == 1
+
+
+# --------------------------------------------------------------------------- #
+# Concurrent reply race — verifies the per-parent asyncio.Lock + cleanup
+# --------------------------------------------------------------------------- #
+
+
+class TestParentLockCleanup:
+    async def test_lock_dict_empties_after_use(self, threadit_bot):
+        import asyncio
+
+        parent_id = 12345
+
+        async def worker():
+            entry = threadit_bot._parent_locks.setdefault(parent_id, [asyncio.Lock(), 0])
+            entry[1] += 1
+            try:
+                async with entry[0]:
+                    await asyncio.sleep(0)
+            finally:
+                entry[1] -= 1
+                if entry[1] == 0:
+                    threadit_bot._parent_locks.pop(parent_id, None)
+
+        await asyncio.gather(*[worker() for _ in range(5)])
+        assert parent_id not in threadit_bot._parent_locks
+
+    async def test_three_concurrent_workers_serialize(self, threadit_bot):
+        """A→B→C must execute strictly serialized, not interleaved."""
+        import asyncio
+
+        parent_id = 99
+        events: list[str] = []
+
+        async def worker(name: str, delay: float):
+            await asyncio.sleep(delay)
+            entry = threadit_bot._parent_locks.setdefault(parent_id, [asyncio.Lock(), 0])
+            entry[1] += 1
+            try:
+                async with entry[0]:
+                    events.append(f"{name}-enter")
+                    await asyncio.sleep(0.01)
+                    events.append(f"{name}-exit")
+            finally:
+                entry[1] -= 1
+                if entry[1] == 0:
+                    threadit_bot._parent_locks.pop(parent_id, None)
+
+        await asyncio.gather(worker("A", 0), worker("B", 0.001), worker("C", 0.002))
+
+        # No interleaving: each worker's enter and exit appear consecutively.
+        for i in range(0, 6, 2):
+            assert events[i + 1] == events[i].replace("-enter", "-exit"), events

--- a/tests/test_bot_helpers.py
+++ b/tests/test_bot_helpers.py
@@ -217,16 +217,23 @@ class TestPermissionWarningRateLimit:
         channel.name = "test"
         channel.send = AsyncMock()
 
+        # Pin time.monotonic() so the test is deterministic regardless of how
+        # long the host has been up. Specifically, return a value that is LESS
+        # than the cooldown — this is the freshly-booted-host scenario where
+        # the prior `0.0` sentinel would have suppressed the very first warning.
+        monotonic_values = iter([10.0, 11.0, 12.0])
         with (
             patch.object(threadit_bot, "check_specific_permission", return_value=True),
             patch.object(threadit_bot, "_client_id", return_value="999"),
+            patch("bot.time.monotonic", side_effect=lambda: next(monotonic_values)),
         ):
             await threadit_bot.send_permission_error_message(channel, ["Embed Links"])
             await threadit_bot.send_permission_error_message(channel, ["Embed Links"])
             await threadit_bot.send_permission_error_message(channel, ["Embed Links"])
 
         assert channel.send.await_count == 1, (
-            "Subsequent warnings must be suppressed by the per-channel cooldown"
+            "First warning must send even on freshly-booted hosts where "
+            "monotonic() < cooldown; subsequent warnings must be suppressed"
         )
 
     async def test_different_channels_are_independent(self, threadit_bot):
@@ -253,24 +260,28 @@ class TestPermissionWarningRateLimit:
 
 
 class TestParentLockCleanup:
+    """
+    These tests drive the production helper ThreadItBot._with_parent_lock
+    directly, so a regression in the lock/cleanup wiring would fail them.
+    """
+
     async def test_lock_dict_empties_after_use(self, threadit_bot):
         import asyncio
 
         parent_id = 12345
 
         async def worker():
-            entry = threadit_bot._parent_locks.setdefault(parent_id, [asyncio.Lock(), 0])
-            entry[1] += 1
-            try:
-                async with entry[0]:
-                    await asyncio.sleep(0)
-            finally:
-                entry[1] -= 1
-                if entry[1] == 0:
-                    threadit_bot._parent_locks.pop(parent_id, None)
+            async with threadit_bot._with_parent_lock(parent_id):
+                await asyncio.sleep(0)
 
         await asyncio.gather(*[worker() for _ in range(5)])
         assert parent_id not in threadit_bot._parent_locks
+
+    async def test_lock_dict_empties_after_single_use(self, threadit_bot):
+        """No-contention case: a single acquire/release must still clean up."""
+        async with threadit_bot._with_parent_lock(42):
+            pass
+        assert 42 not in threadit_bot._parent_locks
 
     async def test_three_concurrent_workers_serialize(self, threadit_bot):
         """A→B→C must execute strictly serialized, not interleaved."""
@@ -281,20 +292,20 @@ class TestParentLockCleanup:
 
         async def worker(name: str, delay: float):
             await asyncio.sleep(delay)
-            entry = threadit_bot._parent_locks.setdefault(parent_id, [asyncio.Lock(), 0])
-            entry[1] += 1
-            try:
-                async with entry[0]:
-                    events.append(f"{name}-enter")
-                    await asyncio.sleep(0.01)
-                    events.append(f"{name}-exit")
-            finally:
-                entry[1] -= 1
-                if entry[1] == 0:
-                    threadit_bot._parent_locks.pop(parent_id, None)
+            async with threadit_bot._with_parent_lock(parent_id):
+                events.append(f"{name}-enter")
+                await asyncio.sleep(0.01)
+                events.append(f"{name}-exit")
 
         await asyncio.gather(worker("A", 0), worker("B", 0.001), worker("C", 0.002))
 
         # No interleaving: each worker's enter and exit appear consecutively.
         for i in range(0, 6, 2):
             assert events[i + 1] == events[i].replace("-enter", "-exit"), events
+
+    async def test_lock_releases_on_exception(self, threadit_bot):
+        """If the body raises, the entry must still be removed (no leak)."""
+        with pytest.raises(RuntimeError, match="boom"):
+            async with threadit_bot._with_parent_lock(77):
+                raise RuntimeError("boom")
+        assert 77 not in threadit_bot._parent_locks

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,103 @@
+"""Tests for config.Config helpers (pure, no Discord I/O)."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+import config
+
+
+class TestGetThreadName:
+    def test_simple_text_passes_through(self):
+        assert config.Config.get_thread_name("hello world") == "hello world"
+
+    def test_empty_returns_fallback(self):
+        assert config.Config.get_thread_name("") == "Discussion Thread"
+
+    def test_whitespace_only_returns_fallback(self):
+        assert config.Config.get_thread_name("   \t\n") == "Discussion Thread"
+
+    def test_strips_user_mention(self):
+        assert config.Config.get_thread_name("hey <@123> what's up") == "hey what's up"
+
+    def test_strips_channel_mention(self):
+        assert config.Config.get_thread_name("check <#456> please") == "check please"
+
+    def test_strips_link(self):
+        assert config.Config.get_thread_name("see https://example.com cool") == "see cool"
+
+    def test_strips_spoiler_and_inline_code(self):
+        assert config.Config.get_thread_name("||hidden|| and `code` ok") == "and ok"
+
+    def test_strips_at_everyone(self):
+        # @everyone must be removed so thread names cannot be misleading.
+        assert config.Config.get_thread_name("hey @everyone what up") == "hey what up"
+
+    def test_strips_at_here_case_insensitive(self):
+        assert config.Config.get_thread_name("hi @Here let us thread") == "hi let us thread"
+
+    def test_strips_zero_width_chars(self):
+        # zero-width space, zero-width joiner: U+200B, U+200D
+        assert config.Config.get_thread_name("zero​width‍join") == "zerowidthjoin"
+
+    def test_strips_bidi_override(self):
+        # right-to-left override U+202E used for spoofing
+        assert config.Config.get_thread_name("‮revert me") == "revert me"
+
+    def test_truncates_to_discord_limit(self):
+        long = "A" * 150
+        result = config.Config.get_thread_name(long)
+        assert len(result) == config.Config.MAX_THREAD_NAME_LENGTH
+        assert result.endswith("...")
+
+    def test_only_stripped_tokens_returns_fallback(self):
+        assert (
+            config.Config.get_thread_name("<@123> https://x.com `code`")
+            == "Discussion Thread"
+        )
+
+
+class TestIntEnv:
+    def test_returns_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("FOO_THREADIT_TEST", raising=False)
+        assert config._int_env("FOO_THREADIT_TEST", 42) == 42
+
+    def test_returns_default_when_empty(self, monkeypatch):
+        monkeypatch.setenv("FOO_THREADIT_TEST", "")
+        assert config._int_env("FOO_THREADIT_TEST", 42) == 42
+
+    def test_parses_valid_int(self, monkeypatch):
+        monkeypatch.setenv("FOO_THREADIT_TEST", "1024")
+        assert config._int_env("FOO_THREADIT_TEST", 42) == 1024
+
+    def test_raises_clear_error_on_garbage(self, monkeypatch):
+        monkeypatch.setenv("FOO_THREADIT_TEST", "abc")
+        with pytest.raises(ValueError, match=r"FOO_THREADIT_TEST.*integer.*'abc'"):
+            config._int_env("FOO_THREADIT_TEST", 42)
+
+
+class TestConfigValidate:
+    def test_passes_when_token_present(self, monkeypatch):
+        monkeypatch.setattr(config.Config, "DISCORD_TOKEN", "real-token-shape")
+        config.Config.validate()
+
+    def test_raises_when_token_missing(self, monkeypatch):
+        monkeypatch.setattr(config.Config, "DISCORD_TOKEN", None)
+        with pytest.raises(ValueError, match="DISCORD_TOKEN"):
+            config.Config.validate()
+
+
+class TestDotenvOrdering:
+    """The original bug: load_dotenv ran AFTER `from config import Config`.
+
+    A regression here means self-hosters following the README would
+    silently get DISCORD_TOKEN=None.
+    """
+
+    def test_config_picks_up_env_at_import_time(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_TOKEN", "loaded-from-env")
+        # Force fresh evaluation of module-level os.getenv.
+        reloaded = importlib.reload(config)
+        assert reloaded.Config.DISCORD_TOKEN == "loaded-from-env"


### PR DESCRIPTION
## Summary

OSS-readiness batch 1 of the follow-ups from PR #3's deferred list. Adds a proper test suite, lint + type CI, and project metadata — the floor of what contributors and reviewers will expect of a public Discord bot.

## What's in the box

### Tooling
- **`pyproject.toml`** — project metadata, `requires-python = ">=3.13"`, ruff/mypy/pytest config in one place.
- **`requirements-dev.txt`** — `ruff`, `mypy`, `pytest`, `pytest-asyncio` layered on top of runtime deps.
- **`tests/`** — 38 unit tests, all passing locally on Python 3.13.

### Test coverage
- `Config.get_thread_name` sanitization: mentions, links, spoilers/code, `@everyone`/`@here`, zero-width chars, bidi overrides, truncation, fallback
- `_int_env` defaults + clear error on garbage
- **dotenv ordering regression** — guards against re-introducing the original critical bug from #3
- `invite_url` + `_client_id` pre-login fallback vs logged-in `self.user.id`
- `_build_attachment_files`: empty, small, oversize (skipped + flagged), download-failure, partial-success (good kept, batch flagged)
- `validate_permissions`: DM-safe, `embed_links` required, `attach_files` conditional on `has_attachments`, `manage_messages` optional
- `send_permission_error_message` per-channel cooldown (first sends, repeats suppressed; different channels independent)
- `_parent_locks` cleanup + strict 3-coroutine A/B/C serialization

### CI
- **`.github/workflows/ci.yml`** — runs `ruff check` + `mypy bot.py config.py` + `pytest` on PRs and master pushes, Python 3.13, pip-cached.
- **`docker.yml`** — replaced the `|| true` masking the Test step with a `grep` for the expected `"DISCORD_TOKEN environment variable not set"` message. A container crash that doesn't print that line is now a CI failure instead of being silently swallowed.

### Source touches (required to pass lint/type)
- Ruff auto-fix: removed 6 extraneous `f` prefixes (F541), the unused `from typing import Optional` imports (F401), one unused unpack (RUF059); UP045 replaced `Optional[str]` with `str | None`.
- Mypy `union-attr`: added explicit `if self.user is None` guards in `validate_permissions`, `check_specific_permission`, and `log_guild_permissions` so the type checker can rule out the pre-login `None` case. Same change is also an honest correctness improvement — these methods could theoretically be hit before `on_ready` and would have AttributeError'd.

## Test plan

- [x] `ruff check .` — clean
- [x] `mypy bot.py config.py` — Success: no issues found
- [x] `pytest` — 38 passed
- [ ] CI workflows go green on this PR

## Not in this PR

Deferred to later follow-ups per the original review backlog:
- Module split (cogs/services), `ReplyInfo` dataclass
- Requirements lockfile (`uv.lock` / pip-tools) — overkill for 2 deps
- `commands.Bot` + Cog + hybrid `/thread-it` slash command
- `on_message_edit` handler; slow-mode interaction
- Health check / heartbeat
- `CONTRIBUTING.md` expansion, CODEOWNERS, issue/PR templates, CHANGELOG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions in README with guidance for installing development dependencies and running linting, type-checking, and test tools.

* **Tests**
  * Added comprehensive unit test coverage for core functionality and configuration validation.

* **Chores**
  * Enhanced CI/CD pipelines with automated code quality checks and Docker image validation.
  * Added project configuration and dependency management files.
  * Updated dependencies to their latest stable versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wei/thread-it/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->